### PR TITLE
Add Comm `data` and `metadata` to widget constructor.

### DIFF
--- a/ypywidgets/ypywidgets.py
+++ b/ypywidgets/ypywidgets.py
@@ -1,23 +1,41 @@
 import asyncio
 from functools import partial
+from typing import Dict, Optional
 from uuid import uuid4
 
-from comm import create_comm
 import y_py as Y
+from comm import create_comm
 
-from .yutils import YMessageType, YSyncMessageType, create_update_message, process_sync_message, put_updates, sync
+from .yutils import (
+    YMessageType,
+    YSyncMessageType,
+    create_update_message,
+    process_sync_message,
+    put_updates,
+    sync,
+)
 
 
 class Widget:
-
-    def __init__(self, name: str, open_comm: bool) -> None:
+    def __init__(
+        self,
+        name: str,
+        open_comm: bool,
+        comm_data: Optional[Dict] = None,
+        comm_metadata: Optional[Dict] = None,
+    ) -> None:
         self.name = name
         self._update_queue = asyncio.Queue()
         self.ydoc = Y.YDoc()
         if open_comm:
             self.synced = asyncio.Event()
             self.comm_id = uuid4().hex
-            self.comm = create_comm(comm_id=self.comm_id, target_name=self.name)
+            self.comm = create_comm(
+                comm_id=self.comm_id,
+                target_name=self.name,
+                data=comm_data,
+                metadata=comm_metadata,
+            )
             self.comm.on_msg(self._receive)
             sync(self.ydoc, self.comm)
             asyncio.create_task(self._send())
@@ -45,7 +63,9 @@ class Widget:
 
     async def _send(self):
         await self.synced.wait()
-        self.ydoc.observe_after_transaction(partial(put_updates, self._update_queue))
+        self.ydoc.observe_after_transaction(
+            partial(put_updates, self._update_queue)
+        )
         while True:
             update = await self._update_queue.get()
             message = create_update_message(update)


### PR DESCRIPTION
This PR allows widgets to send data to the frontend on the `Comm` opening event.