### PR TITLE
Make ypywidgets non-async

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [ '3.7, '3.8', '3.9', '3.10', '3.11' ]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+
+    - name: Upgrade pip
+      run: python3 -m pip install --upgrade pip
+
+    - name: Install ypywidgets in dev mode
+      run: |
+        pip install .[dev]
+
+    - name: Run tests
+      run: |
+        pytest ./tests -v

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://github.com/davidbrochart/ypywidgets/workflows/CI/badge.svg)](https://github.com/davidbrochart/ypywidgets/actions)
+
 # ypywidgets
 
 Y-based Jupyter widgets for Python.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,11 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/davidbrochart/ypywidgets"
 
+[project.optional-dependencies]
+dev = [
+    "pytest",
+]
+
 [tool.hatch.version]
 path = "ypywidgets/__init__.py"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,33 @@
+import comm
+import pytest
+import y_py as Y
+from ypywidgets.yutils import YMessageType, YSyncMessageType, create_update_message, process_sync_message
+
+
+class MockComm(comm.base_comm.BaseComm):
+
+    def publish_msg(self, msg_type, data=None, metadata=None, buffers=None, **keys):
+        if msg_type == "comm_open":
+            self.remote_ydoc = data["remote_ydoc"]
+        elif msg_type == "comm_msg":
+            message = buffers[0]
+            if message[0] == YMessageType.SYNC:
+                process_sync_message(message[1:], self.remote_ydoc, self.send_back)
+                if message[1] == YSyncMessageType.SYNC_STEP2:
+                    self.remote_ydoc.observe_after_transaction(self.receive)
+
+    def send_back(self, buffers):
+        self.handle_msg({"buffers": buffers})
+
+    def handle_msg(self, msg):
+        self._msg_callback(msg)
+
+    def receive(self, event: Y.AfterTransactionEvent):
+        update = event.get_update()
+        message = create_update_message(update)
+        self.handle_msg({"buffers": [message]})
+
+
+@pytest.fixture
+def mock_comm():
+    comm.create_comm = MockComm

--- a/tests/test_comm.py
+++ b/tests/test_comm.py
@@ -1,0 +1,14 @@
+import y_py as Y
+from ypywidgets import Widget
+
+
+def test_comm(mock_comm):
+    ydoc2 = Y.YDoc()
+    widget = Widget("my_widget", True, comm_data={"remote_ydoc": ydoc2})
+    ydoc1 = widget.ydoc
+    ytext1 = ydoc1.get_text("text")
+    text = "hello world!"
+    with ydoc1.begin_transaction() as txn:
+        ytext1.extend(txn, text)
+    ytext2 = ydoc2.get_text("text")
+    assert str(ytext1) == str(ytext2) == text

--- a/ypywidgets/__init__.py
+++ b/ypywidgets/__init__.py
@@ -1,1 +1,4 @@
+from .ypywidgets import Widget  # noqa
+
+
 __version__ = "0.1.3"

--- a/ypywidgets/ypywidgets.py
+++ b/ypywidgets/ypywidgets.py
@@ -1,8 +1,8 @@
 from typing import Dict, Optional
 from uuid import uuid4
 
+import comm
 import y_py as Y
-from comm import create_comm
 
 from .yutils import (
     YMessageType,
@@ -25,7 +25,7 @@ class Widget:
         self.ydoc = Y.YDoc()
         if open_comm:
             self.comm_id = uuid4().hex
-            self.comm = create_comm(
+            self.comm = comm.create_comm(
                 comm_id=self.comm_id,
                 target_name=self.name,
                 data=comm_data,
@@ -51,7 +51,7 @@ class Widget:
     def _receive(self, msg):
         message = bytes(msg["buffers"][0])
         if message[0] == YMessageType.SYNC:
-            process_sync_message(message[1:], self.ydoc, self.comm)
+            process_sync_message(message[1:], self.ydoc, self.comm.send)
             if message[1] == YSyncMessageType.SYNC_STEP2:
                 self.ydoc.observe_after_transaction(self._send)
 

--- a/ypywidgets/yutils.py
+++ b/ypywidgets/yutils.py
@@ -93,14 +93,14 @@ class Decoder:
         return message.decode("utf-8")
 
 
-def process_sync_message(message: bytes, ydoc: Y.YDoc, comm) -> None:
+def process_sync_message(message: bytes, ydoc: Y.YDoc, send_callback) -> None:
     message_type = message[0]
     msg = message[1:]
     if message_type == YSyncMessageType.SYNC_STEP1:
         state = read_message(msg)
         update = Y.encode_state_as_update(ydoc, state)
         reply = create_sync_step2_message(update)
-        comm.send(buffers=[reply])
+        send_callback(buffers=[reply])
     elif message_type in (
         YSyncMessageType.SYNC_STEP2,
         YSyncMessageType.SYNC_UPDATE,

--- a/ypywidgets/yutils.py
+++ b/ypywidgets/yutils.py
@@ -1,4 +1,3 @@
-import asyncio
 from enum import IntEnum
 from typing import Optional
 
@@ -92,10 +91,6 @@ class Decoder:
         if message is None:
             return ""
         return message.decode("utf-8")
-
-
-def put_updates(update_queue: asyncio.Queue, event: Y.AfterTransactionEvent) -> None:
-    update_queue.put_nowait(event.get_update())
 
 
 def process_sync_message(message: bytes, ydoc: Y.YDoc, comm) -> None:


### PR DESCRIPTION
Unlike [ypy-websocket](https://github.com/y-crdt/ypy-websocket) which uses an async implementation of the transport layer (e.g. [websockets](https://github.com/aaugustin/websockets)), [Comm](https://github.com/ipython/comm) is callback-based, so there is no reason to make ypywidgets depend on an async environment.

cc @trungleduc @martinRenou